### PR TITLE
Moves "this.action.output" to closure

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "peerDependencies": {},
   "dependencies": {
     "superagent": "3.5.x",
-    "toki-templater": "1.x.x"
+    "toki-templater": "2.x.x"
   }
 }

--- a/src/implementation.js
+++ b/src/implementation.js
@@ -22,10 +22,12 @@ const configSchema = Joi.object().keys({
 
 module.exports = function () {
 
+    let serverResponse;
+
     return Promise
     .resolve()
     .bind(this)
-    .then( () => Templater(this.action, configSchema, { allowUnknown: true } ) )
+    .then( () => Templater(this.action, configSchema, { hydrationContext: this.contexts, joiOptions: { allowUnknown: true } } ) )
     .then((config) => {
 
         this.config = config.inputConfiguration;
@@ -65,9 +67,9 @@ module.exports = function () {
         return req;
     }).then((response) => {
 
-        this.action.output = response.body;
+        serverResponse = response.body;
     })
-    .then(() => Templater(this.action, configSchema, { allowUnknown: true } )) //we need to re-call the templater to handle mapping our response body
+    .then(() => Templater(this.action, configSchema, {  hydrationContext: serverResponse, joiOptions: { allowUnknown: true } } )) //we need to re-call the templater to handle mapping our response body
     .then((updatedConfig) => {
 
         this.config = updatedConfig;
@@ -76,14 +78,14 @@ module.exports = function () {
 
         if (this.config.clientResponseConfiguration) {
             if (this.config.clientResponseConfiguration === true) {
-                this.response.send(this.action.output);
+                this.response.send(serverResponse);
             }
             else {
                 this.response.send(this.config.clientResponseConfiguration);
             }
         }
 
-        return this.action.output;
+        return serverResponse;
     });
 
 };

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -40,8 +40,9 @@ describe('HTTP Method', () => {
             handler: (req, reply) => {
 
                 reply({
-                    foo: 'bar',
-                    baz: 'biz'
+                    foo  : 'bar',
+                    baz  : 'biz',
+                    break: null
                 });
                 return actionSpies.get(req.payload, req.headers);
             }
@@ -75,7 +76,8 @@ describe('HTTP Method', () => {
         .bind({
             action: {
                 type: 'toki-method-http'
-            }
+            },
+            contexts: {}
         })
         .then(HttpMethod)
         .catch( (e) => {
@@ -94,7 +96,8 @@ describe('HTTP Method', () => {
                 inputConfiguration: {
                     url: 'http://localhost:5000/test'
                 }
-            }
+            },
+            contexts: {}
         })
         .then(HttpMethod)
         .then( () => {
@@ -114,7 +117,8 @@ describe('HTTP Method', () => {
                     url: 'http://localhost:5000/test',
                     method: 'post'
                 }
-            }
+            },
+            contexts: {}
         })
         .then(HttpMethod)
         .then( () => {
@@ -134,7 +138,8 @@ describe('HTTP Method', () => {
                     url: 'http://localhost:5000/test',
                     method: 'post'
                 }
-            }
+            },
+            contexts: {}
         })
         .then(HttpMethod)
         .then( () => {
@@ -156,7 +161,8 @@ describe('HTTP Method', () => {
                     method: 'post',
                     headers: testHeader
                 }
-            }
+            },
+            contexts: {}
         })
         .then(HttpMethod)
         .then( () => {
@@ -180,7 +186,8 @@ describe('HTTP Method', () => {
                     method: 'post',
                     payload: testBody
                 }
-            }
+            },
+            contexts: {}
         })
         .then(HttpMethod)
         .then( () => {
@@ -205,7 +212,8 @@ describe('HTTP Method', () => {
                     payload: testBody,
                     type: 'json'
                 }
-            }
+            },
+            contexts: {}
         })
         .then(HttpMethod)
         .then( () => {
@@ -234,7 +242,8 @@ describe('HTTP Method', () => {
                     'x-arbitrary': 'foo',
                     'x-bar': 'biz'
                 }
-            }
+            },
+            contexts: {}
         })
         .then(HttpMethod)
         .then( () => {
@@ -264,7 +273,8 @@ describe('HTTP Method', () => {
                     'x-arbitrary': 'foo',
                     'x-bar': 'biz'
                 }
-            }
+            },
+            contexts: {}
         })
         .then(HttpMethod)
         .then( () => {
@@ -295,7 +305,8 @@ describe('HTTP Method', () => {
 
                     clientResponse = blah;
                 }
-            }
+            },
+            contexts: {}
         };
 
         return Promise
@@ -306,12 +317,14 @@ describe('HTTP Method', () => {
 
             expect(actionSpies.get.calledOnce).to.be.true();
             expect(output).to.equal({
-                foo: 'bar',
-                baz: 'biz'
+                foo  : 'bar',
+                baz  : 'biz',
+                break: null
             });
             expect(clientResponse).to.equal({
-                foo: 'bar',
-                baz: 'biz'
+                foo  : 'bar',
+                baz  : 'biz',
+                break: null
             });
         });
     });
@@ -329,10 +342,14 @@ describe('HTTP Method', () => {
                     method: 'get'
                 },
                 clientResponseConfiguration: {
-                    foo: 'bar',
-                    baz: 'biz'
+                    data: {
+                        foo  : 'bar',
+                        baz  : 'biz',
+                        break: '{{break}}'
+                    }
                 }
             },
+            contexts: {},
             response: {
                 send: (blah) => {
 
@@ -349,12 +366,16 @@ describe('HTTP Method', () => {
 
             expect(actionSpies.get.calledOnce).to.be.true();
             expect(output).to.equal({
-                foo: 'bar',
-                baz: 'biz'
+                foo  : 'bar',
+                baz  : 'biz',
+                break: null
             });
             expect(clientResponse).to.equal({
-                foo: 'bar',
-                baz: 'biz'
+                data: {
+                    foo  : 'bar',
+                    baz  : 'biz',
+                    break: null
+                }
             });
         });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates toki-templater to v2.x.x . 

No longer stores http response body on `this.action.output`. Toki core already handles that functionality, and by storing the response directly to the `action.output` prior to the second `Templater` call, and server response also gets passed in as part of the template. For the case of this server response, `Templater` was throwing an error in trying to parse `null` as a template:
```js
{
    property1: 'stuff here',
    property2: null
}
```
By moving the response to a closure we maintain the integrity of the runtime context and simultaneously prevent unintended template parsing.


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
none

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Necessary for any non-object, non-string http response property.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.