### PR TITLE
Fix lost "this" context in headers forEach arrow

### DIFF
--- a/src/implementation.js
+++ b/src/implementation.js
@@ -52,11 +52,9 @@ module.exports = function () {
                 req.set(this.server.request.headers);
             }
             else {
-                const self = this;
-
                 this.config.passThroughHeaders.forEach( (header) => {
 
-                    req.set(header, self.server.request.headers[header]);
+                    req.set(header, this.server.request.headers[header]);
                 });
             }
         }

--- a/src/implementation.js
+++ b/src/implementation.js
@@ -49,14 +49,14 @@ module.exports = function () {
         //proxy along  headers
         if (this.config.passThroughHeaders) {
             if (this.config.passThroughHeaders === true) {
-                req.set(this.request.headers);
+                req.set(this.server.request.headers);
             }
             else {
                 const self = this;
 
                 this.config.passThroughHeaders.forEach( (header) => {
 
-                    req.set(header, self.request.headers[header]);
+                    req.set(header, self.server.request.headers[header]);
                 });
             }
         }
@@ -80,10 +80,10 @@ module.exports = function () {
 
         if (this.config.clientResponseConfiguration) {
             if (this.config.clientResponseConfiguration === true) {
-                this.response.send(serverResponse);
+                this.server.response.send(serverResponse);
             }
             else {
-                this.response.send(this.config.clientResponseConfiguration);
+                this.server.response.send(this.config.clientResponseConfiguration);
             }
         }
 

--- a/src/implementation.js
+++ b/src/implementation.js
@@ -52,9 +52,11 @@ module.exports = function () {
                 req.set(this.request.headers);
             }
             else {
+                const self = this;
+
                 this.config.passThroughHeaders.forEach( (header) => {
 
-                    req.set(header, this.request.headers[header]);
+                    req.set(header, self.request.headers[header]);
                 });
             }
         }

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -237,10 +237,12 @@ describe('HTTP Method', () => {
                     passThroughHeaders: true
                 }
             },
-            request: {
-                headers: {
-                    'x-arbitrary': 'foo',
-                    'x-bar': 'biz'
+            server: {
+                request: {
+                    headers: {
+                        'x-arbitrary': 'foo',
+                        'x-bar': 'biz'
+                    }
                 }
             },
             contexts: {}
@@ -268,10 +270,12 @@ describe('HTTP Method', () => {
                     passThroughHeaders: ['x-bar']
                 }
             },
-            request: {
-                headers: {
-                    'x-arbitrary': 'foo',
-                    'x-bar': 'biz'
+            server: {
+                request: {
+                    headers: {
+                        'x-arbitrary': 'foo',
+                        'x-bar': 'biz'
+                    }
                 }
             },
             contexts: {}
@@ -300,10 +304,12 @@ describe('HTTP Method', () => {
                 },
                 clientResponseConfiguration: true
             },
-            response: {
-                send: (blah) => {
+            server: {
+                response: {
+                    send: (blah) => {
 
-                    clientResponse = blah;
+                        clientResponse = blah;
+                    }
                 }
             },
             contexts: {}
@@ -350,10 +356,12 @@ describe('HTTP Method', () => {
                 }
             },
             contexts: {},
-            response: {
-                send: (blah) => {
+            server: {
+                response: {
+                    send: (blah) => {
 
-                    clientResponse = blah;
+                        clientResponse = blah;
+                    }
                 }
             }
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `this` context is lost inside of the arrow callback to `array.forEach`. This creates a `self` closure to provide the lost contextual access.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
none

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Header pass through was breaking with 
```js
TypeError: Cannot read property 'headers' of undefined
    at config.passThroughHeaders.forEach
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All new and existing tests passed.